### PR TITLE
Update packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,5 +4,12 @@
         "url": "https://github.com/chanzuckerberg/cellxgene-census",
         "branch" : "r-universe",
         "subdir":"api/r/cellxgene.census"
+    },
+    {
+        "package": "tiledbsoma",
+        "maintainer": "Aaron Wolen <aaron@tiledb.com>",
+        "url": "https://github.com/single-cell-data/TileDB-SOMA",
+        "available": true,
+        "subdir": "apis/r"
     }
 ]


### PR DESCRIPTION
As discussed with @mlin in slack, a 'hard' dependency that is not on CRAN needs in the list of repos as 'Additional_repositories' only works for 'Suggests:'.  The fix is quite simple:  you can add other (non-CRAN) packages known to other r-universes to your own.

(And if/when `tiledbsoma` is a CRAN package, thiis would no longer be needed ... but can be helpful in case you need to point to different branches or tags.)