### PR TITLE
Switch tiledb-soma to (virtual) branch "*release" to track releases

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10,6 +10,7 @@
         "maintainer": "Aaron Wolen <aaron@tiledb.com>",
         "url": "https://github.com/single-cell-data/TileDB-SOMA",
         "available": true,
+        "branch": "*release",
         "subdir": "apis/r"
     }
 ]


### PR DESCRIPTION
As discussed in https://github.com/single-cell-data/TileDB-SOMA/issues/1427 and on-line meetings, a desire has been expressed to not have builds follow the `main` branch -- but rather follow the tagged releases.  

This PR should accomplish this.