### PR TITLE
switch cellxgene.census to track GitHub Releases

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2,7 +2,7 @@
     {
         "package": "cellxgene.census",
         "url": "https://github.com/chanzuckerberg/cellxgene-census",
-        "branch" : "r-universe",
+        "branch" : "*release",
         "subdir":"api/r/cellxgene.census"
     },
     {


### PR DESCRIPTION
Following discussion of our monorepo versioning strategy, our `cellxgene.census` r-universe package should track GitHub Releases instead of a specific branch.